### PR TITLE
Add build script to obfuscate code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+*.min.js

--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ Add opacity to the body tag and decrease it every day until their site completel
 ```
 
 ## Usage
-Just load the not-paid.js file in ```<head>```
+Just load the `not-paid.js` file in ```<head>```.
+
+### Want to hide it from the client?
+1. `git clone` this repo or download the zip.
+2. Navigate to the project.
+3. Run `npm install` to get [uglify-js](https://www.npmjs.com/package/uglify-js).
+4. Change the variables you need to (as shown above) in `not-paid.js`.
+5. Run `npm run build` and then load the `not-paid.min.js` file in the `<head>` (though probably give it a different name).
 
 ## Author
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "uglifyjs not-paid.js -cm -o not-paid.min.js"
+  },
+  "devDependencies": {
+    "uglify-js": "^3.4.9"
+  }
+}


### PR DESCRIPTION
This PR uses [uglify-js](https://www.npmjs.com/package/uglify-js) with a simple build script (that both compresses the code and hides the variable names) so that should someone wish to minify the code after they've changed the variables, this should do the trick.

#### Resulting code after running the script
```javascript
!function(){var e=new Date("2017-02-27"),t=new Date,a=Date.UTC(e.getFullYear(),e.getMonth(),e.getDate()),g=Date.UTC(t.getFullYear(),t.getMonth(),t.getDate()),n=Math.floor((g-a)/864e5);if(0<n){var l=100*(60-n)/60/100;0<=(l=1<(l=l<0?0:l)?1:l)&&l<=1&&(document.getElementsByTagName("BODY")[0].style.opacity=l)}}();
```