### PR TITLE
Set a variable to say if the client had the payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,16 @@ Add opacity to the body tag and decrease it every day until their site completel
 
 ```javascript
 /* change these variables as you wish */
-	var due_date = new Date('2017-02-27');
-	var days_deadline = 60;
+	var due_date = new Date('2019-02-05')
+	var days_deadline = 5
 /* stop changing here */
 ```
 
 ## Usage
-Just load the not-paid.js file in ```<head>```
+Just load the not-paid.js file in ```<head>```.
+Set the variable ```in_debt``` to ```true``` if the client is in debt, and, if he makes the payment, set to ```false```.
 
 ## Author
 
 Inspired from twitter (@riklomas)
 Made by Ciprian, Romania
-
-## Author note (for Romanians)
-
-MUIE DRAGNEA! 🇷🇴

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>not-paid</title>
+        <script src="not-paid.js"></script>
+    </head>
+    <body>
+        <h1>This is a test with the 'not-paid'</h1>
+    </body>
+</html>

--- a/not-paid.js
+++ b/not-paid.js
@@ -1,23 +1,23 @@
-(function(){
+window.onload = function(){
+	// set if the client is in debt
+	var in_debt = true
 	/* change these variables as you wish */
-	var due_date = new Date('2017-02-27');
-	var days_deadline = 60;
+	var due_date = new Date('2019-02-05')
+	var days_deadline = 5
 	/* stop changing here */
 	
-	var current_date = new Date();
-	var utc1 = Date.UTC(due_date.getFullYear(), due_date.getMonth(), due_date.getDate());
-	var utc2 = Date.UTC(current_date.getFullYear(), current_date.getMonth(), current_date.getDate());
-	var days = Math.floor((utc2 - utc1) / (1000 * 60 * 60 * 24));
+	var current_date = new Date()
+	var utc1 = Date.UTC(due_date.getFullYear(), due_date.getMonth(), due_date.getDate())
+	var utc2 = Date.UTC(current_date.getFullYear(), current_date.getMonth(), current_date.getDate())
+	var days = Math.floor((utc2 - utc1) / (1000 * 60 * 60 * 24))
 	
 	if(days > 0) {
-		var days_late = days_deadline-days;
-		var opacity = (days_late*100/days_deadline)/100;
-			opacity = (opacity < 0) ? 0 : opacity;
-			opacity = (opacity > 1) ? 1 : opacity;
-		if(opacity >= 0 && opacity <= 1) {
-			document.getElementsByTagName("BODY")[0].style.opacity = opacity;
-		}
-		
-	}
-	
-})()
+		var days_late = days_deadline-days
+		var opacity = days_late/days_deadline
+			opacity = (opacity < 0) ? 0 : opacity
+			opacity = (opacity > 1) ? 1 : opacity
+		if(in_debt && opacity >= 0 && opacity <= 1) {
+			document.getElementsByTagName("body")[0].style.opacity = opacity
+		}	
+	}	
+}


### PR DESCRIPTION
Hi @sam3d! I think that this code can stay in a site forever, including the call for script in the index page. I put a variable ```in_debt```, boolean, where we can say if the client made a payment or not (after or during the deadline).
So, rather than put and retire the call for script from time to time, we can just set this variable. It can including stay in other file ```.env```, for example, if you prefer.
I also changed a part of code where had a mathematical redundancy, something like ```(x*100/y)/100```, we can reduce to ```x/y```.
And others little changes, like retire the ```;``` in the end of statments.