### PR TITLE
Simplify getting the body element

### DIFF
--- a/not-paid.js
+++ b/not-paid.js
@@ -16,7 +16,7 @@
 			opacity = (opacity < 0) ? 0 : opacity;
 			opacity = (opacity > 1) ? 1 : opacity;
 		if(opacity >= 0 && opacity <= 1) {
-			document.getElementsByTagName("BODY")[0].style.opacity = opacity;
+			document.body.style.opacity = opacity;
 		}
 		
 	}


### PR DESCRIPTION
Instead of using `getElementsByTagName("BODY")[0]`, you can just use `body`.